### PR TITLE
Add support for the GroupMe API (Client). Add support for the GroupMe…

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -1,0 +1,62 @@
+package groupme
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+// Bot is a GroupMe Bot.
+type Bot struct {
+	BaseURL   string
+	ID        string
+	GroupID   string
+	GroupName string
+	AvatarURL string
+}
+
+// NewBot returns a new GroupMe Bot.
+func NewBot(baseURL, ID, groupID, groupName, avatarURL string) Bot {
+	return Bot{
+		BaseURL:   baseURL,
+		ID:        ID,
+		GroupID:   groupID,
+		GroupName: groupName,
+		AvatarURL: avatarURL,
+	}
+}
+
+// Post . . . TODO
+func (b *Bot) Post(message string) error {
+	// generate URL for request
+	URL, err := createURL(b.BaseURL, "/bots/post", "")
+	if err != nil {
+		return err
+	}
+
+	post := BotPost{
+		BotID: b.ID,
+		Text:  message,
+	}
+
+	jsonStr, err := json.Marshal(post)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", URL, bytes.NewBuffer(jsonStr))
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		return parseError(resp.StatusCode, resp.Status)
+	}
+
+	return nil
+}

--- a/client.go
+++ b/client.go
@@ -1,0 +1,104 @@
+package groupme
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+// Client is a GroupMe API client.
+type Client struct {
+	BaseURL     string
+	AccessToken string
+}
+
+// NewClient returns a new GroupMe API client.
+func NewClient(baseURL, accessToken string) Client {
+	return Client{
+		BaseURL:     baseURL,
+		AccessToken: accessToken,
+	}
+}
+
+// IndexMessages retrieves messages for a group.
+func (c *Client) IndexMessages(groupID string, limit string, beforeID, sinceID, afterID string) (IndexMessagesResponse, error) {
+	// build query params
+	values := url.Values{}
+	values.Add("token", c.AccessToken)
+	if limit != "" {
+		values.Add("limit", limit)
+	}
+	if beforeID != "" {
+		values.Add("before_id", beforeID)
+	}
+	if sinceID != "" {
+		values.Add("since_id", sinceID)
+	}
+	if afterID != "" {
+		values.Add("after_id", afterID)
+	}
+	params := values.Encode()
+
+	// generate URL for request
+	URL, err := createURL(c.BaseURL, fmt.Sprintf("/groups/%s/messages", groupID), params)
+	if err != nil {
+		return IndexMessagesResponse{}, err
+	}
+
+	// send request, read body
+	resp, err := http.Get(URL)
+	if err != nil {
+		return IndexMessagesResponse{}, err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return IndexMessagesResponse{}, err
+	}
+
+	// exit early on error
+	if resp.StatusCode == http.StatusNotModified {
+		return IndexMessagesResponse{}, ErrNotModified
+	}
+
+	// parse response
+	var messages struct {
+		Response IndexMessagesResponse `json:"response"`
+		Meta     Meta                  `json:"meta"`
+	}
+	err = json.Unmarshal(body, &messages)
+	if err != nil {
+		return IndexMessagesResponse{}, err
+	}
+
+	// exit early on error
+	if messages.Meta.Code != http.StatusOK {
+		return IndexMessagesResponse{}, fmt.Errorf("%d: %s", messages.Meta.Code, fmt.Sprintf("%+v", messages.Meta.Errors))
+	}
+
+	return messages.Response, nil
+}
+
+// AllMessages retrieves all messages from a particular group.
+func (c *Client) AllMessages(groupID string) ([]Message, error) {
+	var history []Message
+
+	var beforeID string
+	for {
+		messages, err := c.IndexMessages(groupID, "100", beforeID, "", "")
+		if err != nil {
+			if errors.Is(err, ErrNotModified) {
+				break
+			}
+			return nil, err
+		}
+		beforeID = messages.Messages[len(messages.Messages)-1].ID
+
+		history = append(history, messages.Messages...)
+	}
+
+	return history, nil
+}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,47 @@
+package groupme
+
+import (
+	"errors"
+	"net/http"
+)
+
+// StatusEnhanceYourCalm is "returned when you are being rate limited. Chill the heck out."
+const StatusEnhanceYourCalm = 420
+
+// Errors returned by GroupMe.
+var (
+	ErrNotModified         = errors.New("304 Not Modified")
+	ErrBadRequest          = errors.New("400 Bad Request")
+	ErrUnauthorized        = errors.New("401 Unauthorized")
+	ErrForbidden           = errors.New("403 Forbidden")
+	ErrNotFound            = errors.New("404 Not Found")
+	ErrEnhanceYourCalm     = errors.New("420 Enhance Your Calm")
+	ErrInternalServerError = errors.New("500 Internal Server Error")
+	ErrBadGateway          = errors.New("502 Bad Gateway")
+	ErrServiceUnavailable  = errors.New("503 Service Unavailable")
+)
+
+func parseError(statusCode int, status string) error {
+	switch statusCode {
+	case http.StatusNotModified:
+		return ErrNotModified
+	case http.StatusBadRequest:
+		return ErrBadRequest
+	case http.StatusUnauthorized:
+		return ErrUnauthorized
+	case http.StatusForbidden:
+		return ErrForbidden
+	case http.StatusNotFound:
+		return ErrNotFound
+	case StatusEnhanceYourCalm:
+		return ErrEnhanceYourCalm
+	case http.StatusInternalServerError:
+		return ErrInternalServerError
+	case http.StatusBadGateway:
+		return ErrBadGateway
+	case http.StatusServiceUnavailable:
+		return ErrServiceUnavailable
+	default:
+		return errors.New(status)
+	}
+}

--- a/examples/stats/main.go
+++ b/examples/stats/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/MagnusFrater/groupme"
+)
+
+func main() {
+	accessToken := flag.String("accessToken", "", "GroupMe API client access token")
+	botID := flag.String("botID", "", "GroupMe Bot ID")
+	groupID := flag.String("groupID", "", "Group ID")
+	flag.Parse()
+
+	if *accessToken == "" || *botID == "" || *groupID == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	client := groupme.NewClient(groupme.V3BaseURL, *accessToken)
+	bot := groupme.NewBot(groupme.V3BaseURL, *botID, *groupID, "", "")
+
+	messages, err := client.AllMessages(bot.GroupID)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	stats := newStats(5)
+	stats.parseMessages(messages)
+
+	err = bot.Post(fmt.Sprintf("%s\n%s\n%s",
+		stats.sprintTopOfThePops(5), stats.sprintTopOfTheSimps(5), stats.sprintTopOfTheNarcissists(5)))
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/stats/stats.go
+++ b/examples/stats/stats.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/MagnusFrater/groupme"
+)
+
+type stats struct {
+	Members     map[string]*member
+	TopMessages []groupme.Message
+}
+
+type member struct {
+	ID              string
+	Name            string
+	PopularityScore int // how often did others upvote them
+	SimpScore       int // how many times did they upvote someone else
+	NarcissistScore int // how many times did they upvote themselves
+}
+
+func newStats(limitTopMessages int) stats {
+	return stats{
+		Members:     make(map[string]*member),
+		TopMessages: make([]groupme.Message, 0, limitTopMessages),
+	}
+}
+
+func (s *stats) parseMessages(messages []groupme.Message) {
+	for _, message := range messages {
+		s.incPopularity(message.UserID, message.Name, len(message.FavoritedBy))
+
+		for _, userID := range message.FavoritedBy {
+			if userID == message.UserID {
+				s.incNarcissist(message.UserID, message.Name)
+			} else {
+				s.incSimp(userID, "")
+			}
+		}
+	}
+}
+
+func (s *stats) addMember(userID, name string) {
+	if m, ok := s.Members[userID]; !ok {
+		s.Members[userID] = &member{
+			ID:   userID,
+			Name: name,
+		}
+	} else {
+		if m.Name == "" {
+			m.Name = name
+		}
+	}
+}
+
+func (s *stats) incPopularity(userID, name string, inc int) {
+	s.addMember(userID, name)
+
+	s.Members[userID].PopularityScore += inc
+}
+
+func (s *stats) incSimp(userID, name string) {
+	s.addMember(userID, name)
+
+	s.Members[userID].SimpScore++
+}
+
+func (s *stats) incNarcissist(userID, name string) {
+	s.addMember(userID, name)
+
+	s.Members[userID].NarcissistScore++
+}
+
+func (s *stats) topOfThePops(limit int) []*member {
+	sorted := []*member{}
+
+	for _, member := range s.Members {
+		sorted = append(sorted, member)
+	}
+
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].PopularityScore > sorted[j].PopularityScore })
+
+	top := []*member{}
+	for i := 0; i < limit; i++ {
+		top = append(top, sorted[i])
+	}
+
+	return top
+}
+
+func (s *stats) topOfTheSimps(limit int) []*member {
+	sorted := []*member{}
+
+	for _, member := range s.Members {
+		sorted = append(sorted, member)
+	}
+
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].SimpScore > sorted[j].SimpScore })
+
+	top := []*member{}
+	for i := 0; i < limit; i++ {
+		top = append(top, sorted[i])
+	}
+
+	return top
+}
+
+func (s *stats) topOfTheNarcissists(limit int) []*member {
+	sorted := []*member{}
+
+	for _, member := range s.Members {
+		sorted = append(sorted, member)
+	}
+
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].NarcissistScore > sorted[j].NarcissistScore })
+
+	top := []*member{}
+	for i := 0; i < limit; i++ {
+		top = append(top, sorted[i])
+	}
+
+	return top
+}
+
+func (s *stats) sprintTopOfThePops(limit int) string {
+	str := "Top of the Pops\n(who has the most upvotes)\n==========\n"
+
+	for i, member := range s.topOfThePops(limit) {
+		str += fmt.Sprintf("%d) %s: %d\n", i+1, member.Name, member.PopularityScore)
+	}
+
+	return str
+}
+
+func (s *stats) sprintTopOfTheSimps(limit int) string {
+	str := "Top of the Simps\n(who upvoted other people the most)\n==========\n"
+
+	for i, member := range s.topOfTheSimps(limit) {
+		str += fmt.Sprintf("%d) %s: %d\n", i+1, member.Name, member.SimpScore)
+	}
+
+	return str
+}
+
+func (s *stats) sprintTopOfTheNarcissists(limit int) string {
+	str := "Top of the Narcissists\n(who upvoted themselves the most)\n==========\n"
+
+	for i, member := range s.topOfTheNarcissists(limit) {
+		str += fmt.Sprintf("%d) %s: %d\n", i+1, member.Name, member.NarcissistScore)
+	}
+
+	return str
+}
+
+func (s *stats) printAllMembers() {
+	for _, member := range s.Members {
+		fmt.Printf("%s (%s)\n==========\nPopularity Score: %d\nSimp Score: %d\nNarcissist Score: %d\n\n",
+			member.Name, member.ID, member.PopularityScore, member.SimpScore, member.NarcissistScore)
+	}
+}

--- a/helpers.go
+++ b/helpers.go
@@ -1,0 +1,20 @@
+package groupme
+
+import "net/url"
+
+// V3BaseURL is GroupMe's v3 API base URL.
+const V3BaseURL = "https://api.groupme.com/v3"
+
+func createURL(baseURL, route string, params string) (URL string, err error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	base.Path += route
+
+	if params != "" {
+		base.RawQuery = params
+	}
+
+	return base.String(), nil
+}

--- a/models.go
+++ b/models.go
@@ -1,0 +1,46 @@
+package groupme
+
+// Meta is a
+type Meta struct {
+	Code   int      `json:"code"`
+	Errors []string `json:"errors"`
+}
+
+// IndexMessagesResponse is a GET /groups/:group_id/messages response.
+type IndexMessagesResponse struct {
+	Count    int       `json:"count"`
+	Messages []Message `json:"messages"`
+}
+
+// Message is a GroupMe message.
+type Message struct {
+	ID          string       `json:"id"`
+	SourceGUID  string       `json:"source_guid"`
+	CreatedAt   int          `json:"created_at"`
+	UserID      string       `json:"user_id"`
+	GroupID     string       `json:"group_id"`
+	Name        string       `json:"name"`
+	AvatarURL   string       `json:"avatar_url"`
+	Text        string       `json:"text"`
+	System      bool         `json:"system"`
+	FavoritedBy []string     `json:"favorited_by"`
+	Attachments []Attachment `json:"attachments"`
+}
+
+// Attachment is a GroupMe attachment.
+type Attachment struct {
+	Type        string  `json:"type"`
+	URL         string  `json:"url"`
+	Lat         string  `json:"lat"`
+	Lng         string  `json:"lng"`
+	Name        string  `json:"name"`
+	Token       string  `json:"token"`
+	Placeholder string  `json:"placeholder"`
+	Charmap     [][]int `json:"charmap"`
+}
+
+// BotPost . . . TODO
+type BotPost struct {
+	BotID string `json:"bot_id"`
+	Text  string `json:"text"`
+}


### PR DESCRIPTION
… Bot. Add support for Bot posting a message (POST /bots/post; Bot.Post). Add support for Client retreiving messages for a group (GET /groups/:group_id/messages; Client.IndexMessages). Add support for Client to retreive all messages every sent for a particular group (Client.AllMessages). Add support for GroupMe errors codes as described in their API spec. Create helper method for generating API URL's in a clean, efficient, reusable way. Create models for the API response envelope's 'meta' tag, Client.IndexMessages' response, a GroupMe Message, a GroupMe Message Attachment, and a GroupMe Bot Post. Create 'example' directory for housing code that makes use of the library. Create first example: stats; stats retreives all messages for a given group and parses them to figure out who is the most popular (most upvoted), biggest simp (who upvoted others the most), and biggest narcissist (who upvoted themselves the most). It then posts the results in said GroupMe group.